### PR TITLE
Numba acceleration of the similarity calculation and joblib parallelisation of the outer for loop

### DIFF
--- a/lc2_similarity.py
+++ b/lc2_similarity.py
@@ -1,11 +1,16 @@
 import numpy as np
 from numba import jit, vectorize
+from joblib import Parallel, delayed
+import multiprocessing
+import sys
+
 
 @vectorize
 def clip_below(value, threshold):
     if value < threshold:
         value = threshold
     return value
+
 
 @jit(nopython=True)
 def lc2_similarity(us, mr_and_grad):
@@ -64,6 +69,41 @@ def lc2_similarity(us, mr_and_grad):
 
     return similarity, measure, weight
 
+
+def inner_loop(y, max_y, max_x, img1, img2, patchsize, total_size):
+    """
+    The inner loop of the double for loop in lc2_similarity_patch
+    """
+    b = "\033[1;31;31mProgress: " + str(y) + " / " + str(max_y)
+    sys.stdout.write('\r' + b)
+
+    measure_list = []
+    weights_list = []
+
+    for x in range(max_x):
+
+        # extract patches from us and mr+grad
+        patch1 = img1[
+                 max(0, x - patchsize):min(max_x, x + patchsize),
+                 max(0, y - patchsize):min(max_y, y + patchsize)
+                 ]
+
+        patch2 = img2[
+                 max(0, x - patchsize):min(max_x, x + patchsize),
+                 max(0, y - patchsize):min(max_y, y + patchsize),
+                 :
+                 ]
+
+        # if a patch is bigger than half the maximal size of the patch calculate the similarity
+        # patches that are too small (too close to the border get ignored)
+        if patch1.size > total_size:
+            _, measure, weights = lc2_similarity(patch1, patch2)
+            measure_list.append(measure)
+            weights_list.append(weights)
+
+    return sum(measure_list), sum(weights_list)
+
+
 def lc2_similarity_patch(img1, img2, patchsize=9):
     """
     Calculates the LC2 similarity patch-wise between a 2D US image and the corresponding 2D MR image. The images have to
@@ -84,33 +124,21 @@ def lc2_similarity_patch(img1, img2, patchsize=9):
     # half of the maximal size of the patch
     total_size = ((2*patchsize + 1)**2) / 2
 
-    measure = np.zeros(img1.shape)
-    weights = np.zeros(img1.shape)
+    # measure = np.zeros(img1.shape)
+    # weights = np.zeros(img1.shape)
 
-    # loop through all pixels
-    for y in range(max_y):
-        for x in range(max_x):
+    num_cores = multiprocessing.cpu_count()
 
-            # extract patches from us and mr+grad
-            patch1 = img1[
-                            max(0, x-patchsize):min(max_x, x+patchsize),
-                            max(0, y-patchsize):min(max_y, y+patchsize)
-                     ]
+    return_list = Parallel(n_jobs=num_cores)(delayed(inner_loop)(i, max_y, max_x, img1, img2, patchsize, total_size)
+                                             for i in range(max_y))
 
-            patch2 = img2[
-                            max(0, x-patchsize):min(max_x, x+patchsize),
-                            max(0, y-patchsize):min(max_y, y+patchsize),
-                            :
-                     ]
+    measure_sum = 0
+    weights_sum = 0
 
-            # if a patch is bigger than half the maximal size of the patch calculate the similarity
-            # patches that are too small (too close to the border get ignored)
-            if patch1.size > total_size:
-                _, measure[x, y], weights[x, y] = lc2_similarity(patch1, patch2)
-
-    if np.sum(weights) == 0:
-        return 0
-
-    similarity = np.sum(measure) / np.sum(weights)
+    for elem in return_list:
+        measure_sum += elem[0]
+        weights_sum += elem[1]
+        
+    similarity = measure_sum / weights_sum
 
     return similarity

--- a/lc2_similarity.py
+++ b/lc2_similarity.py
@@ -124,9 +124,6 @@ def lc2_similarity_patch(img1, img2, patchsize=9):
     # half of the maximal size of the patch
     total_size = ((2*patchsize + 1)**2) / 2
 
-    # measure = np.zeros(img1.shape)
-    # weights = np.zeros(img1.shape)
-
     num_cores = multiprocessing.cpu_count()
 
     return_list = Parallel(n_jobs=num_cores)(delayed(inner_loop)(i, max_y, max_x, img1, img2, patchsize, total_size)


### PR DESCRIPTION
Joblib decreased the time from ~20s to ~5.5s
Numba decreased the time from ~5.5s to ~3.5s

(on Mac M1 Pro, patchsize=9, size(images)=642x642)